### PR TITLE
Update maturity level

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 - **Title:** CARD4L (Optical and SAR)
 - **Field Name Prefix:** card4l
 - **Scope:** Item
-- **Extension [Maturity Classification](https://github.com/radiantearth/stac-spec/tree/master/extensions/README.md#extension-maturity):** Proposal
+- **Extension [Maturity Classification](https://github.com/radiantearth/stac-spec/tree/master/extensions/README.md#extension-maturity):** Pilot
 - **Owner**: @m-mohr
 
 This repository contains two STAC extensions that specifies how to create STAC Items (and Collections)


### PR DESCRIPTION
Update the maturity level to **Pilot** following the STAC maturity classification.

Reason: At least 3 known implementations (SH, EODC, TU Jena), but some open (and potentially breaking) issues